### PR TITLE
Remove serviceName from DaemonSet

### DIFF
--- a/hostpath.yaml
+++ b/hostpath.yaml
@@ -124,7 +124,6 @@ spec:
   selector:
     matchLabels:
       app: csi-hostpath-driver
-  serviceName: csi-hostpath
   template:
     metadata:
       labels:


### PR DESCRIPTION
In hostpath.yaml, DeamonSetSpec is incorrect and causes error.
Need remove serviceName from spec.

```
# kubectl create -f hostpath.yaml
serviceaccount "csi-hostpath" created
clusterrole "csi-hostpath-role" created
clusterrolebinding "csi-hostpath-role" created
service "csi-hostpath" created
statefulset "csi-hostpath-ext" created
error: error validating "hostpath.yaml": error validating data: ValidationError(DaemonSet.spec): unknown field "serviceName" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```
